### PR TITLE
Upgrade openssl to fix CVE-2022-2097

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ ENV JAVA_FLAGS="-XX:+UseStringDeduplication -XX:+UseG1GC -XX:+ParallelRefProcEna
 
 WORKDIR /data
 
-RUN addgroup -S paper && \
+RUN apk add --upgrade --no-cache openssl && \
+    addgroup -S paper && \
     adduser -S paper -G paper && \
     chown paper:paper /data
 


### PR DESCRIPTION
We upgrade openssl using `apk add --upgrade --no-cache openssl` in `Dockerfile` to fix [CVE-2022-2097](https://avd.aquasec.com/nvd/2022/cve-2022-2097/).